### PR TITLE
Interpret E notation as underflow or overflow

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -195,8 +195,14 @@ Object.defineProperties(Calculator, {
             } else {
                 let text = value.toString();
                 if (text.toLowerCase().includes("e")) {
-                    // This calculator does not support E notation.
-                    this.setError("ERROR");
+                    if (value < 1 && value > -1) {
+                        // This value is in E notation because it's too close to 0
+                        this.setError("UNDERFLOW");
+                    } else {
+                        // This value is in E notation because it's
+                        // on an extreme on the number line.
+                        this.setError("OVERFLOW");
+                    }
                 } else {
                     this.currentText = text;
                 }


### PR DESCRIPTION
Add an UNDERFLOW error message for cases when numbers go into E notation in JavaScript due to being too close to zero. High-magnitude positive or negative numbers that go to E notation now show an OVERFLOW error message.